### PR TITLE
fix(highlight_deep_nesting): Fixed highlighting to mirror README.md style

### DIFF
--- a/lua/strict/init.lua
+++ b/lua/strict/init.lua
@@ -55,7 +55,7 @@ local function highlight_deep_nesting(
     local regex = string.format(
         '^\\(\\t{%s}\\|\\s\\{%s}\\)' .. -- Matches lines starting with indentation
         '\\zs\\s\\+',              -- Highlights the rest of the line
-	depth_limit,
+        depth_limit,
         indent_limit
     )
 

--- a/lua/strict/init.lua
+++ b/lua/strict/init.lua
@@ -53,7 +53,7 @@ local function highlight_deep_nesting(
     local indent_limit = depth_limit * shift_width
 
     local regex = string.format(
-        '^\\(\\t{%s}\\|\\s\\{%s}\\)' ..
+        '^\\(\\t\\{%s}\\|\\s\\{%s}\\)' ..
         '\\zs\\s\\+',
         depth_limit,
         indent_limit

--- a/lua/strict/init.lua
+++ b/lua/strict/init.lua
@@ -55,6 +55,7 @@ local function highlight_deep_nesting(
     local regex = string.format(
         '^\\(\\t{%s}\\|\\s\\{%s}\\)' .. -- Matches lines starting with indentation
         '\\zs\\s\\+',              -- Highlights the rest of the line
+	depth_limit,
         indent_limit
     )
 

--- a/lua/strict/init.lua
+++ b/lua/strict/init.lua
@@ -53,8 +53,8 @@ local function highlight_deep_nesting(
     local indent_limit = depth_limit * shift_width
 
     local regex = string.format(
-        '^\\(\\t{%s}\\|\\s\\{%s}\\)' .. -- Matches lines starting with indentation
-        '\\zs\\s\\+',              -- Highlights the rest of the line
+        '^\\(\\t{%s}\\|\\s\\{%s}\\)' ..
+        '\\zs\\s\\+',
         depth_limit,
         indent_limit
     )

--- a/lua/strict/init.lua
+++ b/lua/strict/init.lua
@@ -44,29 +44,35 @@ local default_config = {
     }
 }
 
+local function make_char_class(chars)
+    if not chars or chars == '' then return '' end
+    local escaped_chars = chars:gsub("([%]%\\%^%-])", "\\%1")
+    return "[" .. escaped_chars .. "]"
+end
+
 local function highlight_deep_nesting(
     highlight_group, depth_limit, ignored_trailing_characters,
     ignored_leading_characters, match_priority)
-
-    -- Get the num of spaces equal to the depth limit
     local shift_width = vim.bo.shiftwidth
     local indent_limit = depth_limit * shift_width
-
-    local regex = string.format(
-        '^\\(\\t\\{%s}\\|\\s\\{%s}\\)' ..
-        '\\zs\\s\\+',
+    local regex = '^'
+    if ignored_trailing_characters and ignored_trailing_characters ~= '' then
+        local trailing_class = make_char_class(ignored_trailing_characters)
+        regex = regex .. string.format('\\(%s\\n\\)\\@<!', trailing_class)
+    end
+    regex = regex .. string.format(
+        '\\(\\t\\{%s}\\|\\s\\{%s}\\)\\zs',
         depth_limit,
         indent_limit
     )
-
-    -- If ignored trailing or leading characters are specified, adjust the regex
-    if ignored_trailing_characters or ignored_leading_characters then
-        regex = string.format(
-            '\\(%s\\)\\@<!%s\\(%s\\)\\@!',
-            vim.pesc(ignored_trailing_characters or ''),
-            regex,
-            vim.pesc(ignored_leading_characters or '')
+    if ignored_leading_characters and ignored_leading_characters ~= '' then
+        local leading_class = make_char_class(ignored_leading_characters)
+        regex = regex .. string.format(
+            '\\s\\+\\ze\\(\\(%s\\)\\@![^ \\t]\\|$\\)',
+            leading_class
         )
+    else
+        regex = regex .. '\\s\\+\\ze\\([^ \\t]\\|$\\)'
     end
     vim.fn.matchadd(highlight_group, regex, match_priority)
 end
@@ -133,8 +139,11 @@ end
 local function contains(table, value)
     if type(table) ~= 'table' then return false end
     for _, element in ipairs(table) do
-        if type(element) == 'table' then return contains(element, value)
-        elseif element == value then return true end
+        if type(element) == 'table' then
+            return contains(element, value)
+        elseif element == value then
+            return true
+        end
     end
     return false
 end
@@ -223,7 +232,9 @@ local function merge(default, user)
     for key, value in pairs(user) do
         if type(default[key]) == 'table' then
             merge(default[key], value)
-        else default[key] = value end
+        else
+            default[key] = value
+        end
     end
     return default
 end

--- a/lua/strict/init.lua
+++ b/lua/strict/init.lua
@@ -53,8 +53,8 @@ local function highlight_deep_nesting(
     local indent_limit = depth_limit * shift_width
 
     local regex = string.format(
-        '\\(^\\s\\{%s,}\\)' .. -- Matches lines starting with indentation
-        '\\zs.*',              -- Highlights the rest of the line
+        '^\\(\\t{%s}\\|\\s\\{%s}\\)' .. -- Matches lines starting with indentation
+        '\\zs\\s\\+',              -- Highlights the rest of the line
         indent_limit
     )
 


### PR DESCRIPTION
Although #2 fixed the issue that colored all the words in a file. Its fix implemented a different coloring style from the one shown in the [README.md](https://github.com/emileferreira/nvim-strict/blob/main/README.md#nvim-strict). Coloring the line instead of the indentation. Also, removed compatibility with tabs.

This PR fixes both issues.

Closes #3 

<img width="976" height="587" alt="imagen" src="https://github.com/user-attachments/assets/9ce42a9f-96a9-482e-a5bd-03b3559fe909" />
